### PR TITLE
Fix code scanning alert no. 159: Incomplete string escaping or encoding

### DIFF
--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -404,6 +404,7 @@ function safelyCompile(
     }
   }
   value = value
+    .replace(/\\/g, '\\\\') // Escape backslashes
     .replace(/(:|\*|\?|\+|\(|\)|\{|\})/g, '\\$1')
     .replace(/--ESCAPED_PARAM_PLUS/g, '+')
     .replace(/--ESCAPED_PARAM_COLON/g, ':')


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/159](https://github.com/ElProConLag/vercel/security/code-scanning/159)

To fix the problem, we need to ensure that backslashes are properly escaped in the `value` string. This can be done by adding an additional replacement step to escape backslashes before any other characters are escaped. This ensures that any backslashes in the input are treated as literal backslashes and do not interfere with the escaping of other characters.

The best way to fix this without changing existing functionality is to add a replacement step for backslashes right before the existing replacement steps for other characters. This will ensure that all occurrences of backslashes are escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
