### PR TITLE
Fix code scanning alert no. 29: Clear text transmission of sensitive cookie

### DIFF
--- a/examples/sveltekit/src/hooks.js
+++ b/examples/sveltekit/src/hooks.js
@@ -14,7 +14,8 @@ export const handle = async ({ event, resolve }) => {
       'set-cookie',
       cookie.serialize('userid', event.locals.userid, {
         path: '/',
-        httpOnly: true
+        httpOnly: true,
+        secure: true
       })
     );
   }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/29](https://github.com/ElProConLag/vercel/security/code-scanning/29)

To fix the problem, we need to ensure that the `userid` cookie is only transmitted over secure connections. This can be achieved by setting the `secure` attribute on the cookie. This attribute ensures that the cookie is only sent over HTTPS, thus protecting it from being intercepted over unencrypted connections.

We will modify the `cookie.serialize` call to include the `secure` attribute. This change will be made in the `examples/sveltekit/src/hooks.js` file, specifically on line 15 where the cookie is being serialized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
