### PR TITLE
Fix code scanning alert no. 110: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/package.json
+++ b/examples/hexo/themes/landscape/package.json
@@ -8,5 +8,8 @@
     "grunt-git": "~0.2.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1"
+  },
+  "dependencies": {
+    "dompurify": "^3.1.7"
   }
 }

--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -12,6 +12,7 @@
 
 (function(window, document, $, undefined) {
   'use strict';
+  var DOMPurify = require('dompurify')(window);
 
   var H = $('html'),
     W = $(window),
@@ -2128,6 +2129,7 @@
 
   // jQuery plugin initialization
   $.fn.fancybox = function(options) {
+    options = DOMPurify.sanitize(options);
     var index,
       that = $(this),
       selector = this.selector || '',


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/110](https://github.com/ElProConLag/vercel/security/code-scanning/110)

To fix the problem, we need to ensure that any dynamic HTML construction involving user-provided data is properly sanitized. Specifically, we should sanitize the `options` parameter before it is used in any DOM manipulation. This can be achieved by using a library like DOMPurify to clean the input.

1. Import the DOMPurify library.
2. Sanitize the `options` parameter before it is used in the `$.fn.fancybox` function.
3. Ensure that any dynamic HTML construction uses the sanitized data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
