### PR TITLE
Fix code scanning alert no. 113: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
@@ -1,4 +1,5 @@
 /*! fancyBox v2.1.5 fancyapps.com | fancyapps.com/fancybox/#license */
+var DOMPurify = require('dompurify')(window);
 (function(s, H, f, w) {
   var K = f('html'),
     q = f(s),
@@ -1181,6 +1182,7 @@
           !1 !== b.open(h, a) && g.preventDefault());
       };
     a = a || {};
+    a = DOMPurify.sanitize(a); // Sanitize the input
     d = a.index || 0;
     c && !1 !== a.live
       ? p


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/113](https://github.com/ElProConLag/vercel/security/code-scanning/113)

To fix the problem, we need to ensure that any user-controlled input is properly sanitized before being used in a way that could lead to XSS. Specifically, we should sanitize the `a` parameter in the `$.fn.fancybox` function before it is used to construct HTML.

- **General Fix:** Sanitize the user input to remove any potentially harmful content.
- **Detailed Fix:** Use a library like DOMPurify to sanitize the input before it is used. DOMPurify is a well-known library for sanitizing HTML and preventing XSS attacks.
- **Files/Regions/Lines to Change:** The changes will be made in the `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js` file, specifically around the usage of the `a` parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
