### PR TITLE
Fix code scanning alert no. 156: Server-side request forgery

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -2328,10 +2328,25 @@ function proxyPass(
   requestId: string,
   ignorePath: boolean = true
 ): void {
+  const allowedDestinations: { [key: string]: string } = {
+    'example1': 'https://example1.com/data',
+    'example2': 'https://example2.com/data',
+    // Add more allowed destinations as needed
+  };
+
+  const urlObj = new URL(dest);
+  const safeDest = allowedDestinations[urlObj.hostname];
+
+  if (!safeDest) {
+    devServer.output.debug(`Blocked request to unallowed destination: ${dest}`);
+    devServer.sendError(req, res, requestId, 'FORBIDDEN');
+    return;
+  }
+
   return devServer.proxy.web(
     req,
     res,
-    { target: dest, ignorePath },
+    { target: safeDest, ignorePath },
     (error: NodeJS.ErrnoException) => {
       // only debug output this error because it's always something generic like
       // "Error: socket hang up"


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/156](https://github.com/ElProConLag/vercel/security/code-scanning/156)

To fix the SSRF vulnerability, we need to ensure that the `dest` URL is constructed using a controlled and validated input. This can be achieved by implementing an allow-list of acceptable destinations and ensuring that the user input is mapped to one of these predefined destinations.

1. Create a mapping of allowed user inputs to their corresponding safe URLs.
2. Validate the user input against this mapping and use the corresponding safe URL for the `dest` parameter in the `proxyPass` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
