### PR TITLE
Fix code scanning alert no. 109: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
@@ -592,7 +592,7 @@ var DOMPurify = require('dompurify')(window);
             .show();
           b._afterLoad();
         }));
-      a.content = d.appendTo(a.inner);
+      a.content = d.appendTo(DOMPurify.sanitize(a.inner));
       a.iframe.preload || b._afterLoad();
     },
     _preloadImages: function() {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/109](https://github.com/ElProConLag/vercel/security/code-scanning/109)

To fix the problem, we need to ensure that all user inputs are properly sanitized before being used in any context that manipulates the DOM. Specifically, we should sanitize the `a.inner` element before it is appended to the DOM. This can be achieved by using `DOMPurify` to sanitize the content before it is used.

- **General Fix:** Ensure that any dynamic HTML content is sanitized before being inserted into the DOM.
- **Detailed Fix:** Use `DOMPurify.sanitize` to sanitize `a.inner` before it is appended to the DOM in the `_loadIframe` function.
- **Files/Regions/Lines to Change:** Modify the `_loadIframe` function in `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js` to sanitize `a.inner`.
- **Requirements:** The `DOMPurify` library is already imported, so no additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
