### PR TITLE
Fix code scanning alert no. 157: Incomplete string escaping or encoding

### DIFF
--- a/packages/build-utils/src/should-serve.ts
+++ b/packages/build-utils/src/should-serve.ts
@@ -8,7 +8,7 @@ export const shouldServe: ShouldServe = ({
   requestPath,
 }) => {
   requestPath = requestPath.replace(/\/$/, ''); // sanitize trailing '/'
-  entrypoint = entrypoint.replace(/\\/, '/'); // windows compatibility
+  entrypoint = entrypoint.replace(/\\/g, '/'); // windows compatibility
 
   if (entrypoint === requestPath && hasProp(files, entrypoint)) {
     return true;


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/157](https://github.com/ElProConLag/vercel/security/code-scanning/157)

To fix the problem, we need to ensure that all occurrences of the backslash (`\\`) in the `entrypoint` string are replaced with a forward slash (`/`). This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that all backslashes are replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
