### PR TITLE
Fix code scanning alert no. 116: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -2083,6 +2083,8 @@
         return;
       }
 
+      text = DOMPurify.sanitize(text);
+
       title = $(
         '<div class="fancybox-title fancybox-title-' +
           type +


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/116](https://github.com/ElProConLag/vercel/security/code-scanning/116)

To fix the problem, we need to ensure that the `text` variable is sanitized before it is used to construct the `title` element. This can be done using `DOMPurify` to sanitize the `text` content. We will add a call to `DOMPurify.sanitize` for the `text` variable before it is used in the `title` construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
