### PR TITLE
Fix code scanning alert no. 32: Shell command built from environment values

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -154,19 +154,21 @@ export function spawnAsync(
 
 export function spawnCommand(command: string, options: SpawnOptions = {}) {
   const opts = { ...options, prettyCommand: command };
+  const [cmd, ...args] = command.split(' ');
   if (process.platform === 'win32') {
-    return spawn('cmd.exe', ['/C', command], opts);
+    return spawn('cmd.exe', ['/C', cmd, ...args], opts);
   }
 
-  return spawn('sh', ['-c', command], opts);
+  return spawn(cmd, args, opts);
 }
 
 export async function execCommand(command: string, options: SpawnOptions = {}) {
   const opts = { ...options, prettyCommand: command };
+  const [cmd, ...args] = command.split(' ');
   if (process.platform === 'win32') {
-    await spawnAsync('cmd.exe', ['/C', command], opts);
+    await spawnAsync('cmd.exe', ['/C', cmd, ...args], opts);
   } else {
-    await spawnAsync('sh', ['-c', command], opts);
+    await spawnAsync(cmd, args, opts);
   }
 
   return true;


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/32](https://github.com/ElProConLag/vercel/security/code-scanning/32)

To fix the problem, we should avoid using `spawn('sh', ['-c', command], opts)` and instead use `spawn` or `execFile` with arguments passed separately. This approach prevents the shell from interpreting special characters in the `command` string.

1. Modify the `spawnCommand` function to split the `command` into the executable and its arguments.
2. Modify the `execCommand` function to use `spawnAsync` with the executable and arguments separated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
