### PR TITLE
Fix code scanning alert no. 164: Prototype-polluting assignment

### DIFF
--- a/packages/routing-utils/src/merge.ts
+++ b/packages/routing-utils/src/merge.ts
@@ -1,22 +1,18 @@
 import { Route, MergeRoutesProps, Build } from './types';
 import { isHandler, HandleValue } from './index';
 
-interface BuilderToRoute {
-  [use: string]: Route[];
-}
+type BuilderToRoute = Map<string, Route[]>;
 
-interface BuilderRoutes {
-  [entrypoint: string]: BuilderToRoute;
-}
+type BuilderRoutes = Map<string, BuilderToRoute>;
 
-function getBuilderRoutesMapping(builds: Build[]) {
-  const builderRoutes: BuilderRoutes = {};
+function getBuilderRoutesMapping(builds: Build[]): BuilderRoutes {
+  const builderRoutes: BuilderRoutes = new Map();
   for (const { entrypoint, routes, use } of builds) {
     if (routes) {
-      if (!builderRoutes[entrypoint]) {
-        builderRoutes[entrypoint] = {};
+      if (!builderRoutes.has(entrypoint)) {
+        builderRoutes.set(entrypoint, new Map());
       }
-      builderRoutes[entrypoint][use] = routes;
+      builderRoutes.get(entrypoint)!.set(use, routes);
     }
   }
   return builderRoutes;
@@ -68,13 +64,13 @@ export function mergeRoutes({ userRoutes, builds }: MergeRoutesProps): Route[] {
 
   const builderHandleMap = new Map<HandleValue | null, Route[]>();
   const builderRoutes = getBuilderRoutesMapping(builds);
-  const sortedPaths = Object.keys(builderRoutes).sort();
+  const sortedPaths = Array.from(builderRoutes.keys()).sort();
   sortedPaths.forEach(path => {
-    const br = builderRoutes[path];
-    const sortedBuilders = Object.keys(br).sort();
+    const br = builderRoutes.get(path)!;
+    const sortedBuilders = Array.from(br.keys()).sort();
     sortedBuilders.forEach(use => {
       let builderPrevHandle: HandleValue | null = null;
-      br[use].forEach(route => {
+      br.get(use)!.forEach(route => {
         if (isHandler(route)) {
           builderPrevHandle = route.handle;
         } else {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/164](https://github.com/ElProConLag/vercel/security/code-scanning/164)

To fix the prototype pollution issue, we need to ensure that the `entrypoint` value cannot be a dangerous key such as `__proto__`, `constructor`, or `prototype`. One effective way to achieve this is by using a `Map` object instead of a plain JavaScript object for `builderRoutes`. `Map` objects do not have prototype properties and are thus immune to prototype pollution.

**Steps to fix:**
1. Replace the `BuilderToRoute` and `BuilderRoutes` interfaces with `Map` objects.
2. Update the `getBuilderRoutesMapping` function to use `Map` objects for `builderRoutes` and its nested structures.
3. Modify the code that accesses and manipulates `builderRoutes` to use `Map` methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
