### PR TITLE
Fix code scanning alert no. 158: Incomplete string escaping or encoding

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -728,6 +728,7 @@ export async function serverBuild({
         '// @preserve entryDirectory handler',
         `req.url = req.url.replace(/^${path.posix
           .join('/', entryDirectory)
+          .replace(/\\/g, '\\\\')
           .replace(/\//g, '\\/')}/, '')`
       );
     }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/158](https://github.com/ElProConLag/vercel/security/code-scanning/158)

To fix the problem, we need to ensure that all occurrences of the forward slash (`/`) are properly escaped in the `entryDirectory` string. This can be achieved by using a regular expression with the global flag (`g`). Additionally, we should escape backslashes to prevent any potential issues with backslash characters in the input.

- Use a regular expression with the global flag to replace all occurrences of the forward slash.
- Escape backslashes in the `entryDirectory` string before performing the replacement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
