### PR TITLE
Fix code scanning alert no. 100: Reflected cross-site scripting

### DIFF
--- a/packages/node/bench/entrypoint-express.js
+++ b/packages/node/bench/entrypoint-express.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const escapeHtml = require('escape-html');
 
 const app = express();
 
@@ -11,7 +12,8 @@ app.post('*', (req, res) => {
     return res.status(400).send({ error: 'no JSON object in the request' });
   }
 
-  return res.status(200).send(JSON.stringify(req.body, null, 4));
+  const sanitizedBody = escapeHtml(JSON.stringify(req.body, null, 4));
+  return res.status(200).send(sanitizedBody);
 });
 
 app.all('*', (req, res) => {

--- a/packages/node/bench/package.json
+++ b/packages/node/bench/package.json
@@ -6,6 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "express": "4.20.0",
-    "fs-extra": "8.0.1"
+    "fs-extra": "8.0.1",
+    "escape-html": "^1.0.3"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/100](https://github.com/ElProConLag/vercel/security/code-scanning/100)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user-provided data is properly sanitized before being included in the response. In this case, we can use a library like `escape-html` to escape any potentially dangerous characters in the JSON string before sending it in the response.

- **General fix:** Sanitize user input before including it in the response.
- **Detailed fix:** Use the `escape-html` library to escape the JSON string before sending it in the response.
- **Specific changes:** Modify the code in `packages/node/bench/entrypoint-express.js` to include the `escape-html` library and use it to sanitize the JSON string.
- **Requirements:** Add the `escape-html` library to the project dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
