### PR TITLE
Fix code scanning alert no. 37: Incomplete URL substring sanitization

### DIFF
--- a/examples/hydrogen-2/app/components/Header.tsx
+++ b/examples/hydrogen-2/app/components/Header.tsx
@@ -54,10 +54,11 @@ export function HeaderMenu({
         if (!item.url) return null;
 
         // if the url is internal, we strip the domain
+        const parsedUrl = new URL(item.url);
+        const allowedHosts = ['myshopify.com', publicStoreDomain];
         const url =
-          item.url.includes('myshopify.com') ||
-          item.url.includes(publicStoreDomain)
-            ? new URL(item.url).pathname
+          allowedHosts.some(host => parsedUrl.hostname === host || parsedUrl.hostname.endsWith(`.${host}`))
+            ? parsedUrl.pathname
             : item.url;
         return (
           <NavLink


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/37](https://github.com/ElProConLag/vercel/security/code-scanning/37)

To fix the problem, we need to ensure that the URL's host is properly parsed and checked against a whitelist of allowed hosts. This involves:
1. Parsing the URL to extract the host component.
2. Checking if the host matches any of the allowed hosts or their subdomains.
3. Updating the code to use this more secure method of validation.

We will modify the code in `examples/hydrogen-2/app/components/Header.tsx` to implement these changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
