### PR TITLE
Fix code scanning alert no. 31: Shell command built from environment values

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -154,21 +154,14 @@ export function spawnAsync(
 
 export function spawnCommand(command: string, options: SpawnOptions = {}) {
   const opts = { ...options, prettyCommand: command };
-  if (process.platform === 'win32') {
-    return spawn('cmd.exe', ['/C', command], opts);
-  }
-
-  return spawn('sh', ['-c', command], opts);
+  const [cmd, ...args] = command.split(' ');
+  return spawn(cmd, args, opts);
 }
 
 export async function execCommand(command: string, options: SpawnOptions = {}) {
   const opts = { ...options, prettyCommand: command };
-  if (process.platform === 'win32') {
-    await spawnAsync('cmd.exe', ['/C', command], opts);
-  } else {
-    await spawnAsync('sh', ['-c', command], opts);
-  }
-
+  const [cmd, ...args] = command.split(' ');
+  await spawnAsync(cmd, args, opts);
   return true;
 }
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/31](https://github.com/ElProConLag/vercel/security/code-scanning/31)

To fix the problem, we should avoid passing the entire command as a single string to the shell. Instead, we should split the command into the executable and its arguments, and use `spawn` or `execFile` to run the command with arguments separately. This approach prevents the shell from interpreting special characters in the command.

1. Modify the `spawnCommand` function to split the `command` into the executable and its arguments.
2. Use `spawn` or `execFile` to run the command with arguments separately.
3. Ensure that the `execCommand` function also follows the same approach.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
