### PR TITLE
Fix code scanning alert no. 71: Unsafe HTML constructed from library input

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
@@ -672,6 +672,7 @@ var DOMPurify = require('dompurify')(window);
               e = a.tpl.image.replace(/\{href\}/g, g);
               break;
             case 'swf':
+              g = DOMPurify.sanitize(g); // Sanitize the variable g
               (e =
                 '<object id="fancybox-swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%"><param name="movie" value="' +
                 g +


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/71](https://github.com/ElProConLag/vercel/security/code-scanning/71)

To fix the problem, we need to ensure that the variable `g` is properly sanitized before being used in HTML construction. The best way to fix this is to use `DOMPurify` to sanitize `g` before it is used to construct the HTML string for the SWF object. This will prevent any malicious content from being executed.

1. Identify the line where `g` is used to construct the HTML string (line 677).
2. Sanitize `g` using `DOMPurify` before it is used in the HTML string construction.
3. Ensure that the `DOMPurify` library is properly imported and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
