### PR TITLE
Fix code scanning alert no. 115: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
@@ -871,7 +871,7 @@ var DOMPurify = require('dompurify')(window);
               .appendTo(b.outer)
               .bind('click.fb', b.prev),
           (a.loop || a.index < b.group.length - 1) &&
-            f(a.tpl.next)
+            f(DOMPurify.sanitize(a.tpl.next))
               .appendTo(b.outer)
               .bind('click.fb', b.next)),
         b.trigger('afterShow'),


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/115](https://github.com/ElProConLag/vercel/security/code-scanning/115)

To fix the problem, we need to ensure that all dynamic HTML constructions are properly sanitized. This involves using `DOMPurify.sanitize` at every point where untrusted data is inserted into the DOM. Specifically, we should sanitize the content before it is appended to `b.outer` on line 875.

- **General Fix:** Ensure that any dynamic HTML content is sanitized before being inserted into the DOM.
- **Detailed Fix:** Use `DOMPurify.sanitize` to sanitize the content before appending it to `b.outer`.
- **Files/Regions/Lines to Change:** The changes will be made in the file `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js` around line 875.
- **Requirements:** The `DOMPurify` library is already imported, so no additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
