### PR TITLE
Fix code scanning alert no. 160: Incomplete string escaping or encoding

### DIFF
--- a/utils/pack.ts
+++ b/utils/pack.ts
@@ -32,7 +32,7 @@ async function main() {
       for (const dependency of task.dependencies) {
         const name = dependency.split('#')[0];
         // pnpm 8 fails to install dependencies with @ in the URL
-        const escapedName = name.replace('@', '%40');
+        const escapedName = name.replace(/@/g, '%40');
         const tarballUrl = `https://${process.env.VERCEL_URL}/tarballs/${escapedName}.tgz`;
         if (packageObj.dependencies && name in packageObj.dependencies) {
           packageObj.dependencies[name] = tarballUrl;


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/160](https://github.com/ElProConLag/vercel/security/code-scanning/160)

To fix the problem, we need to ensure that all occurrences of the '@' character in the `name` variable are replaced with '%40'. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of '@' in the `name` string is correctly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
