### PR TITLE
Fix code scanning alert no. 36: Incomplete URL substring sanitization

### DIFF
--- a/examples/hydrogen-2/app/components/Footer.tsx
+++ b/examples/hydrogen-2/app/components/Footer.tsx
@@ -18,8 +18,15 @@ function FooterMenu({menu}: Pick<FooterQuery, 'menu'>) {
         if (!item.url) return null;
         // if the url is internal, we strip the domain
         const url =
-          item.url.includes('myshopify.com') ||
-          item.url.includes(publicStoreDomain)
+          (() => {
+            try {
+              const parsedUrl = new URL(item.url);
+              const allowedHosts = ['myshopify.com', publicStoreDomain];
+              return allowedHosts.includes(parsedUrl.host);
+            } catch (e) {
+              return false;
+            }
+          })()
             ? new URL(item.url).pathname
             : item.url;
         const isExternal = !url.startsWith('/');


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/36](https://github.com/ElProConLag/vercel/security/code-scanning/36)

To fix the problem, we need to parse the URL and check the host explicitly instead of using a substring check. This ensures that the URL is genuinely from an allowed domain and not a maliciously crafted one. We will use the `URL` constructor to parse the URL and then check the host against a whitelist of allowed hosts.

1. Parse the URL using the `URL` constructor.
2. Extract the host from the parsed URL.
3. Check if the host is in the list of allowed hosts.
4. If the host is allowed, proceed with the existing logic; otherwise, handle the URL appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
