### PR TITLE
Fix code scanning alert no. 113: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js
@@ -1132,7 +1132,7 @@ var DOMPurify = require('dompurify')(window);
           '<div class="fancybox-title fancybox-title-' +
             c +
             '-wrap">' +
-            e +
+            DOMPurify.sanitize(e) +
             '</div>'
         );
         switch (c) {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/113](https://github.com/ElProConLag/vercel/security/code-scanning/113)

To fix the problem, we need to ensure that all data used in DOM manipulation is properly sanitized. This can be achieved by using `DOMPurify.sanitize` on the specific data being inserted into the DOM, rather than just the top-level input object. This ensures that any nested or dynamically added properties are also sanitized.

- **General Fix:** Sanitize the specific data being inserted into the DOM using `DOMPurify.sanitize`.
- **Detailed Fix:** Apply `DOMPurify.sanitize` to the `e` variable before it is used in the DOM manipulation on line 1135.
- **Files/Regions/Lines to Change:** Modify the code in `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.pack.js` around line 1135.
- **Needed:** No additional methods or imports are required as `DOMPurify` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
