### PR TITLE
Fix code scanning alert no. 33: Unsafe shell command constructed from library input

### DIFF
--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -53,5 +53,8 @@
     "typescript": "4.9.5",
     "yazl": "2.5.1",
     "json5": "2.2.3"
+  },
+  "dependencies": {
+    "shell-quote": "^1.8.1"
   }
 }

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import Sema from 'async-sema';
 import spawn from 'cross-spawn';
+import { quote } from 'shell-quote';
 import {
   coerce,
   intersects,
@@ -124,7 +125,8 @@ export function spawnAsync(
   return new Promise<void>((resolve, reject) => {
     const stderrLogs: Buffer[] = [];
     opts = { stdio: 'inherit', ...opts };
-    const child = spawn(command, args, opts);
+    const escapedArgs = args.map(arg => quote([arg]));
+    const child = spawn(command, escapedArgs, opts);
 
     if (opts.stdio === 'pipe' && child.stderr) {
       child.stderr.on('data', data => stderrLogs.push(data));


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/33](https://github.com/ElProConLag/vercel/security/code-scanning/33)

To fix the problem, we should ensure that the `args` array is properly sanitized or escaped before being passed to the `spawn` function. One way to achieve this is by using the `shell-quote` library to escape any special characters in the `args` array. This will prevent any unintended shell interpretation of the arguments.

1. Install the `shell-quote` library if it is not already installed.
2. Import the `shell-quote` library in the file.
3. Use the `shell-quote` library to escape each argument in the `args` array before passing it to the `spawn` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
