### PR TITLE
Fix code scanning alert no. 162: Information exposure through a stack trace

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1308,7 +1308,8 @@ export default class DevServer {
 
       if (!res.finished) {
         res.statusCode = 500;
-        res.end(errorToString(err));
+        this.output.debug(`Error occurred: ${errorToString(err)}`);
+        res.end("An internal server error occurred.");
       }
     }
   };


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/162](https://github.com/ElProConLag/vercel/security/code-scanning/162)

To fix the problem, we should ensure that detailed error information, such as stack traces, is not sent back to the client. Instead, we should log the detailed error information on the server and send a generic error message to the client. This can be achieved by modifying the `devServerHandler` function to log the error and send a generic message.

- **General Fix:** Log the detailed error information on the server and send a generic error message to the client.
- **Detailed Fix:** Modify the `devServerHandler` function in `packages/cli/src/util/dev/server.ts` to log the error using `this.output.debug` and send a generic error message to the client.
- **Specific Changes:**
  - Replace the call to `res.end(errorToString(err))` with a generic error message.
  - Ensure that the detailed error information is logged on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
