### PR TITLE
Fix code scanning alert no. 112: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1624,13 +1624,13 @@
       // Create navigation arrows
       if (current.arrows && F.group.length > 1) {
         if (current.loop || current.index > 0) {
-          $(current.tpl.prev)
+          $(DOMPurify.sanitize(current.tpl.prev))
             .appendTo(F.outer)
             .bind('click.fb', F.prev);
         }
 
         if (current.loop || current.index < F.group.length - 1) {
-          $(current.tpl.next)
+          $(DOMPurify.sanitize(current.tpl.next))
             .appendTo(F.outer)
             .bind('click.fb', F.next);
         }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/112](https://github.com/ElProConLag/vercel/security/code-scanning/112)

To fix the problem, we need to ensure that any content being inserted into the DOM is properly sanitized. Although `DOMPurify.sanitize` is used initially, we should add an additional layer of sanitization right before the content is inserted into the DOM. This can be done by using `DOMPurify.sanitize` again on the specific content being appended.

- **General Fix:** Ensure that any content being inserted into the DOM is sanitized using `DOMPurify.sanitize`.
- **Detailed Fix:** Apply `DOMPurify.sanitize` to the content being appended to `F.outer` on line 1634.
- **Files/Regions/Lines to Change:** Modify the code in `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js` around line 1634.
- **Needed:** No new methods or imports are required since `DOMPurify` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
