### PR TITLE
Fix code scanning alert no. 80: Unsafe HTML constructed from library input

### DIFF
--- a/packages/cli/test/dev/fixtures/07-hexo-node/themes/landscape/package.json
+++ b/packages/cli/test/dev/fixtures/07-hexo-node/themes/landscape/package.json
@@ -8,5 +8,8 @@
     "grunt-git": "~0.2.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1"
+  },
+  "dependencies": {
+    "dompurify": "^3.1.7"
   }
 }

--- a/packages/cli/test/dev/fixtures/07-hexo-node/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/packages/cli/test/dev/fixtures/07-hexo-node/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1130,8 +1130,8 @@ import DOMPurify from 'dompurify';
 					embed   = '';
 
 					$.each(current.swf, function(name, val) {
-						content += '<param name="' + name + '" value="' + val + '"></param>';
-						embed   += ' ' + name + '="' + val + '"';
+						content += '<param name="' + DOMPurify.sanitize(name) + '" value="' + DOMPurify.sanitize(val) + '"></param>';
+						embed   += ' ' + DOMPurify.sanitize(name) + '="' + DOMPurify.sanitize(val) + '"';
 					});
 
 					content += '<embed src="' + DOMPurify.sanitize(href) + '" type="application/x-shockwave-flash" width="100%" height="100%"' + embed + '></embed></object>';

--- a/packages/cli/test/dev/fixtures/07-hexo-node/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/packages/cli/test/dev/fixtures/07-hexo-node/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 /*!
  * fancyBox - jQuery Plugin
  * version: 2.1.5 (Fri, 14 Jun 2013)
@@ -10,7 +11,7 @@
  *
  */
 
-;(function (window, document, $, undefined) {
+;(function (window, document, $, DOMPurify, undefined) {
 	"use strict";
 
 	var H = $("html"),
@@ -1133,7 +1134,7 @@
 						embed   += ' ' + name + '="' + val + '"';
 					});
 
-					content += '<embed src="' + href + '" type="application/x-shockwave-flash" width="100%" height="100%"' + embed + '></embed></object>';
+					content += '<embed src="' + DOMPurify.sanitize(href) + '" type="application/x-shockwave-flash" width="100%" height="100%"' + embed + '></embed></object>';
 				break;
 			}
 
@@ -2014,4 +2015,4 @@
 		$("<style type='text/css'>.fancybox-margin{margin-right:" + (w2 - w1) + "px;}</style>").appendTo("head");
 	});
 
-}(window, document, jQuery));
+}(window, document, jQuery, DOMPurify));


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/80](https://github.com/ElProConLag/vercel/security/code-scanning/80)

To fix the problem, we need to ensure that any user-supplied data used in constructing HTML is properly sanitized or escaped to prevent XSS attacks. The best way to fix this issue is to use a library like `DOMPurify` to sanitize the `href` value before using it in the HTML construction. This approach ensures that any potentially harmful content is removed, while still allowing the intended functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
