### PR TITLE
Fix code scanning alert no. 150: DOM text reinterpreted as HTML

### DIFF
--- a/examples/hexo/themes/landscape/source/js/script.js
+++ b/examples/hexo/themes/landscape/source/js/script.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 (function($) {
   // Search
   var $searchWrap = $('#search-form-wrap'),
@@ -40,7 +42,7 @@
       e.stopPropagation();
 
       var $this = $(this),
-        url = $this.attr('data-url'),
+        url = DOMPurify.sanitize($this.attr('data-url')),
         encodedUrl = encodeURIComponent(url),
         id = 'article-share-box-' + $this.attr('data-id'),
         offset = $this.offset();


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/150](https://github.com/ElProConLag/vercel/security/code-scanning/150)

To fix the problem, we need to ensure that any data read from the DOM and reinserted as HTML is properly escaped to prevent XSS attacks. The best way to fix this issue is to use a library like `DOMPurify` to sanitize the `data-url` attribute before using it in the HTML string. This will ensure that any potentially malicious content is neutralized.

1. Import the `DOMPurify` library.
2. Sanitize the `data-url` attribute using `DOMPurify.sanitize`.
3. Use the sanitized URL in the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
