### PR TITLE
Fix code scanning alert no. 67: Unsafe HTML constructed from library input

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1212,7 +1212,7 @@
         case 'swf':
           content =
             '<object id="fancybox-swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%"><param name="movie" value="' +
-            href +
+            DOMPurify.sanitize(href) +
             '"></param>';
           embed = '';
 
@@ -1224,7 +1224,7 @@
 
           content +=
             '<embed src="' +
-            href +
+            DOMPurify.sanitize(href) +
             '" type="application/x-shockwave-flash" width="100%" height="100%"' +
             embed +
             '></embed></object>';


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/67](https://github.com/ElProConLag/vercel/security/code-scanning/67)

To fix the problem, we need to ensure that any dynamic HTML construction involving potentially untrusted data is properly sanitized. Specifically, we should sanitize the `href` value before it is used in the HTML string construction. This can be achieved by using `DOMPurify` to sanitize the `href` value directly.

1. Identify the point where `href` is used to construct HTML (line 1215).
2. Sanitize the `href` value using `DOMPurify` before it is inserted into the HTML string.
3. Ensure that the `DOMPurify` library is correctly imported and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
