### PR TITLE
Fix code scanning alert no. 110: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1613,7 +1613,7 @@
       // Create a close button
       if (current.closeBtn) {
         $(current.tpl.closeBtn)
-          .appendTo(F.skin)
+          .appendTo(DOMPurify.sanitize(F.skin))
           .bind('click.fb', function(e) {
             e.preventDefault();
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/110](https://github.com/ElProConLag/vercel/security/code-scanning/110)

To fix the problem, we need to ensure that any data used in DOM manipulations is properly sanitized. Although `DOMPurify.sanitize` is used initially, we should add additional checks and sanitization at critical points where the data is used, especially before it is inserted into the DOM.

- Ensure that the `options` parameter is sanitized at the point of use.
- Specifically, sanitize the `F.skin` element before it is appended to the DOM.
- Use `DOMPurify.sanitize` to clean the content before any DOM manipulation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
