### PR TITLE
Fix code scanning alert no. 151: DOM text reinterpreted as HTML

### DIFF
--- a/examples/hexo/themes/landscape/source/js/script.js
+++ b/examples/hexo/themes/landscape/source/js/script.js
@@ -118,12 +118,13 @@ import DOMPurify from 'dompurify';
         )
           return;
 
-        var alt = this.alt;
+        var alt = DOMPurify.sanitize(this.alt);
+        var src = DOMPurify.sanitize(this.src);
 
         if (alt) $(this).after('<span class="caption">' + alt + '</span>');
 
         $(this).wrap(
-          '<a href="' + this.src + '" title="' + alt + '" class="fancybox"></a>'
+          '<a href="' + src + '" title="' + alt + '" class="fancybox"></a>'
         );
       });
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/151](https://github.com/ElProConLag/vercel/security/code-scanning/151)

To fix the problem, we need to ensure that any data used to construct HTML strings is properly sanitized or escaped to prevent XSS attacks. The best way to fix this issue is to use `DOMPurify` to sanitize the `src` and `alt` attributes before inserting them into the DOM.

- We will sanitize `this.src` and `alt` using `DOMPurify.sanitize` before constructing the HTML string.
- This change will be made in the file `examples/hexo/themes/landscape/source/js/script.js` on line 126.
- We will ensure that `DOMPurify` is properly imported and used in the relevant part of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
