### PR TITLE
Fix code scanning alert no. 68: Unsafe HTML constructed from library input

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1218,8 +1218,8 @@
 
           $.each(current.swf, function(name, val) {
             content +=
-              '<param name="' + name + '" value="' + val + '"></param>';
-            embed += ' ' + name + '="' + val + '"';
+              '<param name="' + DOMPurify.sanitize(name) + '" value="' + DOMPurify.sanitize(val) + '"></param>';
+            embed += ' ' + DOMPurify.sanitize(name) + '="' + DOMPurify.sanitize(val) + '"';
           });
 
           content +=


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/68](https://github.com/ElProConLag/vercel/security/code-scanning/68)

To fix the problem, we need to ensure that all dynamic HTML constructions are properly sanitized. The best way to achieve this is by using `DOMPurify` to sanitize any untrusted data before it is used to construct HTML. This will prevent any potential XSS attacks.

- **General Fix:** Use `DOMPurify` to sanitize any untrusted data before it is used in dynamic HTML construction.
- **Detailed Fix:** Specifically, sanitize the `content` variable before it is used in constructing HTML in the `_afterLoad` method.
- **Files/Regions/Lines to Change:** The changes will be made in the `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js` file, particularly around lines 1220 and 1225.
- **Requirements:** Ensure `DOMPurify` is imported and used correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
