### PR TITLE
Fix code scanning alert no. 163: Information exposure through a stack trace

### DIFF
--- a/packages/node/src/dev-server.mts
+++ b/packages/node/src/dev-server.mts
@@ -152,7 +152,8 @@ async function onDevRequest(
     }
   } catch (error: any) {
     res.statusCode = 500;
-    res.end(error.stack);
+    logError("Exception occurred", error.stack);
+    res.end("An internal server error occurred");
   }
 }
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/163](https://github.com/ElProConLag/vercel/security/code-scanning/163)

To fix the problem, we need to ensure that stack traces are not sent to the client. Instead, we should log the stack trace on the server and send a generic error message to the client. This can be achieved by modifying the `onDevRequest` function to log the error stack trace and send a generic error message.

- Modify the `onDevRequest` function to log the error stack trace using the `logError` function.
- Send a generic error message to the client instead of the stack trace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
