### PR TITLE
Fix code scanning alert no. 150: DOM text reinterpreted as HTML

### DIFF
--- a/examples/hexo/themes/landscape/source/js/script.js
+++ b/examples/hexo/themes/landscape/source/js/script.js
@@ -44,7 +44,7 @@ import DOMPurify from 'dompurify';
       var $this = $(this),
         url = DOMPurify.sanitize($this.attr('data-url')),
         encodedUrl = encodeURIComponent(url),
-        id = 'article-share-box-' + $this.attr('data-id'),
+        id = 'article-share-box-' + DOMPurify.sanitize($this.attr('data-id')),
         offset = $this.offset();
 
       if ($('#' + id).length) {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/150](https://github.com/ElProConLag/vercel/security/code-scanning/150)

To fix the problem, we need to ensure that the `data-id` attribute is properly sanitized before being used to construct HTML content. We can use `DOMPurify` to sanitize the `data-id` attribute, similar to how the `data-url` attribute is sanitized. This will prevent any malicious content from being interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
