### PR TITLE
Fix code scanning alert no. 104: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1054,7 +1054,8 @@
 
     _loadIframe: function() {
       var coming = F.coming,
-        iframe = $(coming.tpl.iframe.replace(/\{rnd\}/g, new Date().getTime()))
+        sanitizedIframeTpl = DOMPurify.sanitize(coming.tpl.iframe),
+        iframe = $(sanitizedIframeTpl.replace(/\{rnd\}/g, new Date().getTime()))
           .attr('scrolling', isTouch ? 'auto' : coming.iframe.scrolling)
           .attr('src', coming.href);
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/104](https://github.com/ElProConLag/vercel/security/code-scanning/104)

To fix the problem, we need to ensure that any dynamic HTML construction using user-provided data is properly sanitized. Specifically, we should sanitize the `coming.tpl.iframe` content before it is used in the `replace` function. This can be done by using `DOMPurify` to sanitize the `coming.tpl.iframe` string.

- In general terms, sanitize any user-provided data before using it in dynamic HTML construction.
- Specifically, sanitize `coming.tpl.iframe` before using it in the `replace` function.
- The changes should be made in the `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js` file.
- We will use the existing `DOMPurify` instance to sanitize the `coming.tpl.iframe` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
