### PR TITLE
Fix code scanning alert no. 103: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -331,6 +331,7 @@
         if (!content) {
           if (type === 'inline') {
             if (href) {
+              href = isString(href) ? DOMPurify.sanitize(href) : href;
               content = $(
                 isString(href) ? href.replace(/.*(?=#[^\s]+$)/, '') : href
               ); //strip for ie7


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/103](https://github.com/ElProConLag/vercel/security/code-scanning/103)

To fix the problem, we need to ensure that any dynamic HTML construction involving the `href` variable is properly sanitized. This can be achieved by using `DOMPurify` to sanitize the `href` variable before it is used in any DOM manipulation.

- In general terms, we need to sanitize the `href` variable before it is used in the `replace` method.
- Specifically, we will use `DOMPurify.sanitize` to clean the `href` variable before it is processed.
- The changes will be made in the `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js` file, particularly around line 335 where the `href` variable is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
