### PR TITLE
Fix code scanning alert no. 184: Unsafe HTML constructed from library input

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1224,6 +1224,7 @@
             embed += ' ' + DOMPurify.sanitize(name) + '="' + DOMPurify.sanitize(val) + '"';
           });
 
+          content = DOMPurify.sanitize(content);
           content +=
             '<embed src="' +
             DOMPurify.sanitize(href) +


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/184](https://github.com/ElProConLag/vercel/security/code-scanning/184)

To fix the problem, we need to ensure that all dynamic HTML constructions are safe from XSS attacks. This can be achieved by consistently using `DOMPurify.sanitize` on all potentially unsafe inputs before they are used to construct HTML. Specifically, we should sanitize the `content` variable before it is used in the HTML construction on line 1227.

- **General Fix:** Ensure that all dynamic HTML constructions use sanitized inputs.
- **Detailed Fix:** Sanitize the `content` variable using `DOMPurify.sanitize` before it is used in the HTML construction on line 1227.
- **Specific Changes:** Modify the code in `examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js` to sanitize `content` before it is used.
- **Requirements:** No new methods or imports are needed as `DOMPurify` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
