### PR TITLE
Fix code scanning alert no. 103: Unsafe jQuery plugin

### DIFF
--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -333,9 +333,8 @@
           if (type === 'inline') {
             if (href) {
               href = isString(href) ? DOMPurify.sanitize(href) : href;
-              content = $(
-                isString(href) ? href.replace(/.*(?=#[^\s]+$)/, '') : href
-              ); //strip for ie7
+              href = isString(href) ? href.replace(/.*(?=#[^\s]+$)/, '') : href;
+              content = $(href); //strip for ie7
             } else if (obj.isDom) {
               content = element;
             }

--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -332,8 +332,8 @@
         if (!content) {
           if (type === 'inline') {
             if (href) {
-              href = isString(href) ? DOMPurify.sanitize(href) : href;
               href = isString(href) ? href.replace(/.*(?=#[^\s]+$)/, '') : href;
+              href = isString(href) ? DOMPurify.sanitize(href) : href;
               content = $(href); //strip for ie7
             } else if (obj.isDom) {
               content = element;

--- a/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/examples/hexo/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -290,10 +290,10 @@
           }
         }
 
-        href = opts.href || obj.href || (isString(element) ? element : null);
+        href = DOMPurify.sanitize(opts.href) || obj.href || (isString(element) ? element : null);
         title = opts.title !== undefined ? opts.title : obj.title || '';
 
-        content = opts.content || obj.content;
+        content = DOMPurify.sanitize(opts.content) || obj.content;
         type = content ? 'html' : opts.type || obj.type;
 
         if (!type && obj.isDom) {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/vercel/security/code-scanning/103](https://github.com/ElProConLag/vercel/security/code-scanning/103)

To fix the problem, we need to ensure that all user inputs are properly sanitized before being used in any dynamic HTML construction. Specifically, we should sanitize the `href` variable consistently before it is used in any DOM manipulation.

- Ensure that `href` is sanitized before it is used in the `replace` method.
- Apply `DOMPurify.sanitize` to `href` in all relevant places to prevent any potential XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
