### PR TITLE
Potential fix for code scanning alert no. 193: Failure to use secure cookies

### DIFF
--- a/packages/python/test/fixtures/20-multivalue-header/api/cookie_handler.py
+++ b/packages/python/test/fixtures/20-multivalue-header/api/cookie_handler.py
@@ -5,8 +5,8 @@ class handler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
         self.send_header('content-type', 'text/plain')
-        self.send_header('set-cookie', 'one=first')
-        self.send_header('set-cookie', 'two=second')
+        self.send_header('set-cookie', 'one=first; Secure; HttpOnly; SameSite=Strict')
+        self.send_header('set-cookie', 'two=second; Secure; HttpOnly; SameSite=Strict')
         self.end_headers()
         self.wfile.write('handler:RANDOMNESS_PLACEHOLDER'.encode())
         return


### PR DESCRIPTION
Potential fix for [https://github.com/ElProConLag/vercel/security/code-scanning/193](https://github.com/ElProConLag/vercel/security/code-scanning/193)

To fix the issue, we need to ensure that all cookies set in the response include the `Secure`, `HttpOnly`, and `SameSite` attributes. This can be achieved by modifying the `set-cookie` headers to include these attributes explicitly. The `Secure` attribute ensures cookies are only sent over HTTPS, `HttpOnly` prevents JavaScript access, and `SameSite=Strict` mitigates CSRF risks.

The changes will involve updating the `send_header` calls on lines 8 and 9 to include these attributes in the cookie values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
