### PR TITLE
Potential fix for code scanning alert no. 192: Failure to use secure cookies

### DIFF
--- a/packages/python/test/fixtures/20-multivalue-header/api/cookie_handler.py
+++ b/packages/python/test/fixtures/20-multivalue-header/api/cookie_handler.py
@@ -5,8 +5,8 @@ class handler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
         self.send_header('content-type', 'text/plain')
-        self.send_header('set-cookie', 'one=first')
-        self.send_header('set-cookie', 'two=second')
+        self.send_header('set-cookie', 'one=first; Secure; HttpOnly; SameSite=Strict')
+        self.send_header('set-cookie', 'two=second; Secure; HttpOnly; SameSite=Strict')
         self.end_headers()
         self.wfile.write('handler:RANDOMNESS_PLACEHOLDER'.encode())
         return


### PR DESCRIPTION
Potential fix for [https://github.com/ElProConLag/vercel/security/code-scanning/192](https://github.com/ElProConLag/vercel/security/code-scanning/192)

To fix the issue, we need to ensure that the cookies set in the `set-cookie` headers include the `Secure`, `HttpOnly`, and `SameSite` attributes. This can be achieved by appending these attributes to the cookie values. Specifically:
- Add `; Secure` to ensure the cookie is only transmitted over HTTPS.
- Add `; HttpOnly` to prevent JavaScript access to the cookie.
- Add `; SameSite=Strict` to restrict the cookie to same-site requests.

The changes will be made directly to the `set-cookie` headers on lines 8 and 9.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
