### PR TITLE
Potential fix for code scanning alert no. 191: Server-side request forgery

### DIFF
--- a/packages/next/test/fixtures/00-middleware-i18n/middleware.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/middleware.js
@@ -230,8 +230,11 @@ export function middleware(request) {
   }
 
   if (pathname.startsWith('/fetch-subrequest')) {
-    const destinationUrl =
-      url.searchParams.get('url') || 'https://example.vercel.sh';
+    const ALLOWED_URLS = ['https://example.vercel.sh', 'https://api.example.com'];
+    const userProvidedUrl = url.searchParams.get('url');
+    const destinationUrl = ALLOWED_URLS.includes(userProvidedUrl)
+      ? userProvidedUrl
+      : 'https://example.vercel.sh';
     return fetch(destinationUrl, { headers: request.headers });
   }
 

--- a/packages/next/test/fixtures/00-middleware-i18n/middleware.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/middleware.js
@@ -231,9 +231,16 @@ export function middleware(request) {
 
   if (pathname.startsWith('/fetch-subrequest')) {
     const userProvidedUrl = url.searchParams.get('url');
-    const destinationUrl = ALLOWED_URLS.includes(userProvidedUrl)
-      ? userProvidedUrl
-      : 'https://example.vercel.sh';
+    let destinationUrl = 'https://example.vercel.sh';
+
+    try {
+      const parsedUrl = new URL(userProvidedUrl);
+      if (ALLOWED_URLS.includes(parsedUrl.origin)) {
+        destinationUrl = parsedUrl.toString();
+      }
+    } catch (error) {
+      console.error('Invalid URL provided:', userProvidedUrl);
+    }
     return fetch(destinationUrl, { headers: request.headers });
   }
 

--- a/packages/next/test/fixtures/00-middleware-i18n/middleware.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/middleware.js
@@ -231,9 +231,21 @@ export function middleware(request) {
 
   if (pathname.startsWith('/fetch-subrequest')) {
     const userProvidedUrl = url.searchParams.get('url');
-    let destinationUrl = 'https://example.vercel.sh';
-
-    try {
+    const userProvidedUrlString = url.searchParams.get('url');
+    let isValidAndAllowed = false;
+    if (userProvidedUrlString) {
+      try {
+        const parsedUserUrl = new URL(userProvidedUrlString);
+        // Assuming ALLOWED_URLS contains origins like 'https://example.com'
+        if (ALLOWED_URLS.includes(parsedUserUrl.origin)) {
+          isValidAndAllowed = true;
+        }
+      } catch (e) {
+        // Invalid URL string, isValidAndAllowed remains false.
+        // Consider logging `e.message` for debugging if appropriate.
+      }
+    }
+    const destinationUrl = isValidAndAllowed ? userProvidedUrlString : 'https://example.vercel.sh';
       const parsedUrl = new URL(userProvidedUrl);
       if (ALLOWED_URLS.includes(parsedUrl.origin)) {
         destinationUrl = parsedUrl.toString();

--- a/packages/next/test/fixtures/00-middleware-i18n/middleware.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/middleware.js
@@ -230,7 +230,6 @@ export function middleware(request) {
   }
 
   if (pathname.startsWith('/fetch-subrequest')) {
-    const ALLOWED_URLS = ['https://example.vercel.sh', 'https://api.example.com'];
     const userProvidedUrl = url.searchParams.get('url');
     const destinationUrl = ALLOWED_URLS.includes(userProvidedUrl)
       ? userProvidedUrl


### PR DESCRIPTION
Potential fix for [https://github.com/ElProConLag/vercel/security/code-scanning/191](https://github.com/ElProConLag/vercel/security/code-scanning/191)

To fix the issue, we need to validate and restrict the `url` query parameter before using it in the `fetch` call. Specifically:
1. Implement an allow-list of permitted URLs or domains to ensure that only safe destinations are used.
2. If the `url` parameter does not match the allow-list, fall back to a default safe URL (`'https://example.vercel.sh'`).

This approach ensures that user input cannot dictate arbitrary destinations for outgoing requests, mitigating the SSRF vulnerability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
