### PR TITLE
Potential fix for code scanning alert no. 190: Server-side request forgery

### DIFF
--- a/packages/next/test/fixtures/00-middleware-base-path/middleware.js
+++ b/packages/next/test/fixtures/00-middleware-base-path/middleware.js
@@ -237,6 +237,24 @@ export function middleware(request) {
   if (pathname.startsWith('/fetch-subrequest')) {
     const destinationUrl =
       url.searchParams.get('url') || 'https://example.vercel.sh';
+    
+    // Allowlist of permitted domains
+    const ALLOWED_DOMAINS = ['example.vercel.sh', 'api.example.com'];
+    try {
+      const parsedUrl = new URL(destinationUrl);
+      if (!ALLOWED_DOMAINS.includes(parsedUrl.hostname)) {
+        return NextResponse.json(
+          { error: 'Invalid URL' },
+          { status: 400 }
+        );
+      }
+    } catch (e) {
+      return NextResponse.json(
+        { error: 'Malformed URL' },
+        { status: 400 }
+      );
+    }
+    
     return fetch(destinationUrl, { headers: request.headers });
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ElProConLag/vercel/security/code-scanning/190](https://github.com/ElProConLag/vercel/security/code-scanning/190)

To fix the SSRF vulnerability, we need to validate and restrict the user-provided `url` parameter before using it in the `fetch` function. Specifically:
1. Use an allowlist of permitted URLs or domains to ensure that only safe destinations are allowed.
2. Reject or sanitize any input that does not match the allowlist.

In this case, we will implement an allowlist of permitted domains and validate the `destinationUrl` against it. If the `destinationUrl` is not in the allowlist, we will return an error response instead of making the request.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
