### PR TITLE
Potential fix for code scanning alert no. 189: Server-side request forgery

### DIFF
--- a/packages/next/test/fixtures/00-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-middleware/middleware.js
@@ -237,8 +237,21 @@ export function middleware(request) {
   }
 
   if (pathname.startsWith('/fetch-subrequest')) {
-    const destinationUrl =
-      url.searchParams.get('url') || 'https://example.vercel.sh';
+    const ALLOWED_DOMAINS = ['example.vercel.sh', 'api.example.com'];
+    const userProvidedUrl = url.searchParams.get('url');
+    let destinationUrl = 'https://example.vercel.sh'; // Default safe URL
+
+    if (userProvidedUrl) {
+      try {
+        const parsedUrl = new URL(userProvidedUrl);
+        if (ALLOWED_DOMAINS.includes(parsedUrl.hostname)) {
+          destinationUrl = parsedUrl.toString();
+        }
+      } catch (e) {
+        console.error('Invalid URL provided:', userProvidedUrl);
+      }
+    }
+
     return fetch(destinationUrl, { headers: request.headers });
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ElProConLag/vercel/security/code-scanning/189](https://github.com/ElProConLag/vercel/security/code-scanning/189)

To fix the SSRF vulnerability, we need to validate and restrict the user-provided `url` parameter before using it in the `fetch` call. The best approach is to use an allow-list of trusted domains or URLs. If the user-provided URL does not match the allow-list, we should reject it or fall back to a safe default value.

Steps to implement the fix:
1. Define an allow-list of trusted domains or URLs.
2. Parse the user-provided `url` parameter and check if it matches the allow-list.
3. If the `url` is not in the allow-list, reject it or use a safe default value.
4. Update the `fetch` call to use the validated URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
