### PR TITLE
Potential fix for code scanning alert no. 195: Server-side request forgery

### DIFF
--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -128,8 +128,8 @@ export default class Client extends EventEmitter implements Stdio {
     const url = new URL(_url, this.apiUrl);
 
     // Validate that the hostname matches the expected apiUrl hostname
-    if (url.hostname !== new URL(this.apiUrl).hostname) {
-      throw new Error(`Invalid URL hostname: ${url.hostname}`);
+    if (url.hostname !== this.apiHostname) { // Assuming this.apiHostname is pre-calculated in the constructor
+      throw new Error(`Invalid URL hostname: ${url.hostname}. Expected ${this.apiHostname}.`);
     }
 
     if (opts.accountId || opts.useCurrentTeam !== false) {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -127,6 +127,11 @@ export default class Client extends EventEmitter implements Stdio {
   private _fetch(_url: string, opts: FetchOptions = {}) {
     const url = new URL(_url, this.apiUrl);
 
+    // Validate that the hostname matches the expected apiUrl hostname
+    if (url.hostname !== new URL(this.apiUrl).hostname) {
+      throw new Error(`Invalid URL hostname: ${url.hostname}`);
+    }
+
     if (opts.accountId || opts.useCurrentTeam !== false) {
       if (opts.accountId) {
         if (opts.accountId.startsWith('team_')) {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -140,13 +140,10 @@ export default class Client extends EventEmitter implements Stdio {
     if (url.pathname.includes('..')) {
       throw new Error('Path traversal attempt detected.');
     }
-    // Define a whitelist of allowed path prefixes
-    const allowedPathPrefixes = ['/api/', '/v1/', '/v2/'];
-
     // Validate that the path starts with one of the allowed prefixes
-    if (!allowedPathPrefixes.some(prefix => url.pathname.startsWith(prefix))) {
+    if (!ALLOWED_PATH_PREFIXES.some(prefix => url.pathname.startsWith(prefix))) {
       throw new Error(
-        `Invalid path: ${url.pathname}. Path must start with one of the allowed prefixes: ${allowedPathPrefixes.join(', ')}.`
+        `Invalid path: ${url.pathname}. Path must start with one of the allowed prefixes: ${ALLOWED_PATH_PREFIXES.join(', ')}.`
       );
     }
 

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -140,11 +140,15 @@ export default class Client extends EventEmitter implements Stdio {
     if (url.pathname.includes('..')) {
       throw new Error('Path traversal attempt detected.');
     }
-    // Add additional path validation if needed, for example, checking for allowed prefixes:
-    // if (!url.pathname.startsWith('/allowed-prefix/')) {
-    //   throw new Error(`Invalid path: ${url.pathname}. Path must start with /allowed-prefix/.`);
-    // }
+    // Define a whitelist of allowed path prefixes
+    const allowedPathPrefixes = ['/api/', '/v1/', '/v2/'];
 
+    // Validate that the path starts with one of the allowed prefixes
+    if (!allowedPathPrefixes.some(prefix => url.pathname.startsWith(prefix))) {
+      throw new Error(
+        `Invalid path: ${url.pathname}. Path must start with one of the allowed prefixes: ${allowedPathPrefixes.join(', ')}.`
+      );
+    }
 
     if (opts.accountId || opts.useCurrentTeam !== false) {
       if (opts.accountId) {

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -28,7 +28,7 @@ export function createProxy(client: Client): Server {
               throw new Error('Invalid query parameter detected');
             }
           }
-          return parsedUrl.pathname + '?' + searchParams.toString();
+          return parsedUrl.pathname + (searchParams.toString() ? '?' + searchParams.toString() : '');
         } catch {
           return '/';
         }

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -16,7 +16,8 @@ export function createProxy(client: Client): Server {
       // Proxy to the upstream Vercel REST API
       const headers = toHeaders(req.headers);
       headers.delete('host');
-      const fetchRes = await client.fetch(req.url || '/', {
+      const sanitizedUrl = req.url && req.url.startsWith('/') ? req.url : '/';
+      const fetchRes = await client.fetch(sanitizedUrl, {
         headers,
         method: req.method,
         body: req.method === 'GET' || req.method === 'HEAD' ? undefined : req,

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -22,7 +22,13 @@ export function createProxy(client: Client): Server {
           if (parsedUrl.pathname.includes('..')) {
             throw new Error('Path traversal attempt detected');
           }
-          return parsedUrl.pathname + parsedUrl.search;
+          const searchParams = new URLSearchParams(parsedUrl.search);
+          for (const [key, value] of searchParams.entries()) {
+            if (key.includes('..') || value.includes('..')) {
+              throw new Error('Invalid query parameter detected');
+            }
+          }
+          return parsedUrl.pathname + '?' + searchParams.toString();
         } catch {
           return '/';
         }


### PR DESCRIPTION
Potential fix for [https://github.com/ElProConLag/vercel/security/code-scanning/195](https://github.com/ElProConLag/vercel/security/code-scanning/195)

To fix the SSRF vulnerability, we need to validate and sanitize the user-provided `req.url` before using it to construct the outgoing request URL. Specifically:
1. Restrict the hostname or base URL to a predefined allowlist to prevent redirection to unintended endpoints.
2. Validate the path component of the URL to prevent path traversal attacks or other malicious manipulations.

In this case, we will:
- Introduce a validation function to ensure that the constructed URL's hostname matches the expected `apiUrl` hostname.
- Reject or sanitize any invalid or unexpected paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
