### PR TITLE
Potential fix for code scanning alert no. 195: Server-side request forgery

### DIFF
--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -127,6 +127,11 @@ export default class Client extends EventEmitter implements Stdio {
   private _fetch(_url: string, opts: FetchOptions = {}) {
     const url = new URL(_url, this.apiUrl);
 
+    // Validate that the hostname matches the expected apiUrl hostname
+    if (url.hostname !== new URL(this.apiUrl).hostname) {
+      throw new Error(`Invalid URL hostname: ${url.hostname}`);
+    }
+
     if (opts.accountId || opts.useCurrentTeam !== false) {
       if (opts.accountId) {
         if (opts.accountId.startsWith('team_')) {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -128,7 +128,7 @@ export default class Client extends EventEmitter implements Stdio {
     const url = new URL(_url, this.apiUrl);
 
     // Validate that the hostname matches the expected apiUrl hostname
-    if (url.hostname !== new URL(this.apiUrl).hostname) {
+    if (url.hostname !== this._apiHostname) {
       throw new Error(`Invalid URL hostname: ${url.hostname}`);
     }
 

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -16,7 +16,8 @@ export function createProxy(client: Client): Server {
       // Proxy to the upstream Vercel REST API
       const headers = toHeaders(req.headers);
       headers.delete('host');
-      const fetchRes = await client.fetch(req.url || '/', {
+      const sanitizedUrl = req.url && req.url.startsWith('/') ? req.url : '/';
+      const fetchRes = await client.fetch(sanitizedUrl, {
         headers,
         method: req.method,
         body: req.method === 'GET' || req.method === 'HEAD' ? undefined : req,

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -16,7 +16,7 @@ export function createProxy(client: Client): Server {
       // Proxy to the upstream Vercel REST API
       const headers = toHeaders(req.headers);
       headers.delete('host');
-      const apiUrl = 'http://localhost'; // Base URL for resolving relative paths
+      const apiUrl = client.apiUrl || 'http://localhost'; // Use client's configured base URL or fallback to localhost
       const sanitizedUrl = req.url ? (() => {
         const urlInstance = new URL(req.url, apiUrl);
         return urlInstance.pathname + urlInstance.search;

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -17,10 +17,7 @@ export function createProxy(client: Client): Server {
       const headers = toHeaders(req.headers);
       headers.delete('host');
       const apiUrl = client.apiUrl || 'http://localhost'; // Use client's configured base URL or fallback to localhost
-      const sanitizedUrl = req.url ? (() => {
-        const urlInstance = new URL(req.url, apiUrl);
-        return urlInstance.pathname + urlInstance.search;
-      })() : '/';
+      const sanitizedUrl = sanitizeUrl(req.url, apiUrl);
       const fetchRes = await client.fetch(sanitizedUrl, {
         headers,
         method: req.method,

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -17,7 +17,10 @@ export function createProxy(client: Client): Server {
       const headers = toHeaders(req.headers);
       headers.delete('host');
       const apiUrl = 'http://localhost'; // Base URL for resolving relative paths
-      const sanitizedUrl = req.url ? new URL(req.url, apiUrl).pathname + new URL(req.url, apiUrl).search : '/';
+      const sanitizedUrl = req.url ? (() => {
+        const urlInstance = new URL(req.url, apiUrl);
+        return urlInstance.pathname + urlInstance.search;
+      })() : '/';
       const fetchRes = await client.fetch(sanitizedUrl, {
         headers,
         method: req.method,

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -16,7 +16,8 @@ export function createProxy(client: Client): Server {
       // Proxy to the upstream Vercel REST API
       const headers = toHeaders(req.headers);
       headers.delete('host');
-      const sanitizedUrl = req.url && req.url.startsWith('/') ? req.url : '/';
+      const apiUrl = 'http://localhost'; // Base URL for resolving relative paths
+      const sanitizedUrl = req.url ? new URL(req.url, apiUrl).pathname + new URL(req.url, apiUrl).search : '/';
       const fetchRes = await client.fetch(sanitizedUrl, {
         headers,
         method: req.method,


### PR DESCRIPTION
Potential fix for [https://github.com/ElProConLag/vercel/security/code-scanning/195](https://github.com/ElProConLag/vercel/security/code-scanning/195)

To fix the SSRF vulnerability, we need to validate and sanitize the user-provided `req.url` before using it to construct the outgoing request URL. Specifically:
1. Restrict the hostname or base URL to a predefined allowlist to prevent redirection to unintended endpoints.
2. Validate the path component of the URL to prevent path traversal attacks or other malicious manipulations.

In this case, we will:
- Introduce a validation function to ensure that the constructed URL's hostname matches the expected `apiUrl` hostname.
- Reject or sanitize any invalid or unexpected paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
